### PR TITLE
Corrección práctica 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Verificación y Validación
 # Práctica 3: Pruebas dinámicas de código con JUnit
 
-Proyecto de partida para la realización de la práctica 3 de
+Solución del equipo 5 a la práctica 3 de
 Verificación y Validación del Grado en Ingeniería Informática de
 la Universidad de Zaragoza. El enunciado completo se
 encuentra en Moodle. 

--- a/src/test/java/es/unizar/eina/vv6f/practica3/ContadorDeLetrasTest.java
+++ b/src/test/java/es/unizar/eina/vv6f/practica3/ContadorDeLetrasTest.java
@@ -32,7 +32,7 @@ class ContadorDeLetrasTest {
     public void comprobar_Fichero_Hamlet() throws FileNotFoundException {
         ContadorDeLetras contador = new ContadorDeLetras(new File("src/main/res/hamlet.txt"));
         int[] vectoraComparar = leerFichero(new File("src/test/res/salida-hamlet.txt"));
-        assertArrayEquals(contador.frecuencias(),vectoraComparar);
+        assertArrayEquals(vectoraComparar, contador.frecuencias());
 
     }
 
@@ -40,14 +40,14 @@ class ContadorDeLetrasTest {
     public void comprobar_Fichero_Quijote() throws  FileNotFoundException{
         ContadorDeLetras contador = new ContadorDeLetras(new File("src/main/res/quijote.txt"));
         int[] vectoraComparar = leerFichero(new File("src/test/res/salida-quijote.txt"));
-        assertArrayEquals(contador.frecuencias(),vectoraComparar);
+        assertArrayEquals(vectoraComparar,contador.frecuencias());
     }
 
     @Test   //Test numero 5 para comprobar la correcta lectura de los carácteres del fichero Regenta
     public void comprobar_Fichero_Regenta() throws  FileNotFoundException{
         ContadorDeLetras contador = new ContadorDeLetras(new File("src/main/res/regenta.txt"));
         int[] vectoraComparar = leerFichero(new File("src/test/res/salida-regenta.txt"));
-        assertArrayEquals(contador.frecuencias(),vectoraComparar);
+        assertArrayEquals(vectoraComparar,contador.frecuencias());
     }
 
     @Test  //Test numero 6 para comprobar la correcta lectura de las letras minúsculas
@@ -57,7 +57,7 @@ class ContadorDeLetrasTest {
         for (int i = 0; i<27; i++){
             vectoraComparar[i] = 1;
         }
-        assertArrayEquals(contador.frecuencias(),vectoraComparar);
+        assertArrayEquals(vectoraComparar,contador.frecuencias());
     }
 
     @Test  //Test numero 7 para comprobar la correcta lectura de las letras mayusculas
@@ -67,7 +67,7 @@ class ContadorDeLetrasTest {
         for (int i = 0; i<27; i++){
             vectoraComparar[i] = 1;
         }
-        assertArrayEquals(contador.frecuencias(),vectoraComparar);
+        assertArrayEquals(vectoraComparar,contador.frecuencias());
     }
 
     @Test  //Test numero 8 para comprobar la correcta lectura de las letras minúsculas acentuadas
@@ -79,7 +79,7 @@ class ContadorDeLetrasTest {
         vectoraComparar['i'-'a'] = 3;
         vectoraComparar['o'-'a'] = 3;
         vectoraComparar['u'-'a'] = 3;
-        assertArrayEquals(contador.frecuencias(),vectoraComparar);
+        assertArrayEquals(vectoraComparar,contador.frecuencias());
     }
 
     @Test  //Test numero 9 para comprobar la correcta lectura de las letras mayusculas acentuadas
@@ -91,7 +91,7 @@ class ContadorDeLetrasTest {
         vectoraComparar['i'-'a'] = 3;
         vectoraComparar['o'-'a'] = 3;
         vectoraComparar['u'-'a'] = 3;
-        assertArrayEquals(contador.frecuencias(),vectoraComparar);
+        assertArrayEquals(vectoraComparar,contador.frecuencias());
     }
 
     @Test  //Test numero 10 para comprobar la correcta lectura de la letra egne (mayuscula y minuscula)
@@ -99,7 +99,7 @@ class ContadorDeLetrasTest {
         ContadorDeLetras contador = new ContadorDeLetras(new File("src/main/res/egne.txt"));
         int[] vectoraComparar = new int[27];
         vectoraComparar[26] = 2;
-        assertArrayEquals(contador.frecuencias(), vectoraComparar);
+        assertArrayEquals(vectoraComparar, contador.frecuencias());
     }
 
     @Test  //Test numero 11 para comprobar la correcta lectura de la letra cedilla (mayuscula y minuscula)
@@ -107,14 +107,14 @@ class ContadorDeLetrasTest {
         ContadorDeLetras contador = new ContadorDeLetras(new File("src/main/res/cedilla.txt"));
         int[] vectoraComparar = new int[27];
         vectoraComparar['c'-'a'] = 2;
-        assertArrayEquals(contador.frecuencias(), vectoraComparar);
+        assertArrayEquals(vectoraComparar, contador.frecuencias());
     }
 
     @Test  //Test numero 12 para comprobar la correcta lectura de otros carácteres que no forman parte del abecedario
     public void comprobar_otros() throws  FileNotFoundException {
         ContadorDeLetras contador = new ContadorDeLetras(new File("src/main/res/otros.txt"));
         int[] vectoraComparar = new int[27];
-        assertArrayEquals(contador.frecuencias(), vectoraComparar);
+        assertArrayEquals(vectoraComparar, contador.frecuencias());
     }
 
     @Test  //Test numero 13 para comprobar la correcta lectura de las letras voladas ª y º
@@ -123,7 +123,7 @@ class ContadorDeLetrasTest {
         int[] vectoraComparar = new int[27];
         vectoraComparar['o' - 'a'] = 1;
         vectoraComparar[0] = 1;
-        assertArrayEquals(contador.frecuencias(),vectoraComparar);
+        assertArrayEquals(vectoraComparar,contador.frecuencias());
     }
     @Test  //Test numero 14 para comprobar la correcta lectura cuando this.frecuencias es no nulo
     public void comprobar_frecuencia_no_nulo() throws IOException,FileNotFoundException {
@@ -138,7 +138,7 @@ class ContadorDeLetrasTest {
         fw.write("ÁÀÄÉÈËÍÌÏÓÒÖÚÙÜ");
         fw.close();
         ContadorDeLetras contadorSolucion = new ContadorDeLetras(new File("src/main/res/mayusAcentuadas.txt"));
-        assertArrayEquals(contador.frecuencias(),contadorSolucion.frecuencias());
+        assertArrayEquals(contadorSolucion.frecuencias(),contador.frecuencias());
     }
     /**
      *

--- a/src/test/java/es/unizar/eina/vv6f/practica3/ContadorDeLetrasTest.java
+++ b/src/test/java/es/unizar/eina/vv6f/practica3/ContadorDeLetrasTest.java
@@ -127,6 +127,10 @@ class ContadorDeLetrasTest {
     }
     @Test  //Test numero 14 para comprobar la correcta lectura cuando this.frecuencias es no nulo
     public void comprobar_frecuencia_no_nulo() throws IOException,FileNotFoundException {
+        /* No entiendo lo que pretende este test. La idea era simplemente comprobar que una segunda
+        invocación a frecuencias() sigue devolviendo el valor correcto.
+         */
+
         String file = "src/main/res/mayusModificada.txt";
         FileWriter fw=new FileWriter(file);
         fw.write("QWERTYUIOPASDFGHJKLZXCVBNMÑ");

--- a/src/test/java/es/unizar/eina/vv6f/practica3/MainTest.java
+++ b/src/test/java/es/unizar/eina/vv6f/practica3/MainTest.java
@@ -58,9 +58,6 @@ class MainTest {
         ByteArrayInputStream byteArrayQuijote = new ByteArrayInputStream("src/main/res/quijote.txt".getBytes());
         System.setIn(byteArrayQuijote);
 
-        ficheroTempo = new File("src/main/res/salida_Artificial.txt");
-        PrintStream salidaArtificial = new PrintStream(ficheroTempo);
-        System.setOut(salidaArtificial);
 
         Main.main(null);
         //Array de bytes con la salida estandar de nuestra main
@@ -79,10 +76,6 @@ class MainTest {
         ByteArrayInputStream byteArrayQuijote = new ByteArrayInputStream("src/main/res/regenta.txt".getBytes());
         System.setIn(byteArrayQuijote);
 
-        ficheroTempo = new File("src/main/res/salida_Artificial.txt");
-        PrintStream salidaArtificial = new PrintStream(ficheroTempo);
-        System.setOut(salidaArtificial);
-
         Main.main(null);
         //Array de bytes con la salida estandar de nuestra main
         File s = ajusta_fichero(ficheroTempo);
@@ -99,10 +92,6 @@ class MainTest {
 
         ByteArrayInputStream byteArrayQuijote = new ByteArrayInputStream("src/main/res/hamlet.txt".getBytes());
         System.setIn(byteArrayQuijote);
-
-        ficheroTempo = new File("src/main/res/salida_Artificial.txt");
-        PrintStream salidaArtificial = new PrintStream(ficheroTempo);
-        System.setOut(salidaArtificial);
 
         Main.main(null);
         //Array de bytes con la salida estandar de nuestra main


### PR DESCRIPTION
El diseño de las pruebas es correcto, con la técnica de particiones de equivalencia bien aplicada, aunque en el diseño de los casos de prueba hubiera sido necesario indicar explícitamente cual es el contenido exacto de los ficheros (por ejemplo: mayúsculas.txt = "ABCDEFGHIJKLMNOPQRSTUVWXYZ") e indicar en la columna resultado esperado qué vector en concreto se espera (ejemplo, {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0}.

En las pruebas de desarrollo, es correcta la utilización de un método auxiliar leerFichero() para obtener los vectores con los resultados esperados a partir del contenido de los ficheros de las trazas de ejecución. De todas formas, esto hace que los test ejecuten mucho código y aumentamos la probabilidad de que haya defectos en el código de los test. Se podría haber mejorado añadiendo también una test de unidad a ese método auxiliar.

Para las pruebas de sistema, podríais haber utilizado también todos los casos de prueba que habéis diseñado. 

He corregido alguna cosa más en la rama «corr-prof» de vuestro repositorio de GitHub. Podéis ir viendo commit a commit las modificaciones.